### PR TITLE
Added support for "startapp" parameter in Telegram universal URLs

### DIFF
--- a/packages/sdk/src/provider/bridge/bridge-provider.ts
+++ b/packages/sdk/src/provider/bridge/bridge-provider.ts
@@ -346,7 +346,8 @@ export class BridgeProvider implements HTTPProvider {
 
         const startattach = 'tonconnect-' + encodeTelegramUrlParameters(linkParams);
         const url = new URL(universalLink);
-        url.searchParams.append('startattach', startattach);
+        const paramName = url.searchParams.has('startapp') ? 'startapp' : 'startattach';
+        url.searchParams.append(paramName, startattach);
         return url.toString();
     }
 

--- a/packages/sdk/src/provider/bridge/bridge-provider.ts
+++ b/packages/sdk/src/provider/bridge/bridge-provider.ts
@@ -344,10 +344,10 @@ export class BridgeProvider implements HTTPProvider {
         const urlToWrap = this.generateRegularUniversalLink('about:blank', message);
         const linkParams = urlToWrap.split('?')[1]!;
 
-        const startattach = 'tonconnect-' + encodeTelegramUrlParameters(linkParams);
+        const paramValue = 'tonconnect-' + encodeTelegramUrlParameters(linkParams);
         const url = new URL(universalLink);
         const paramName = url.searchParams.has('startapp') ? 'startapp' : 'startattach';
-        url.searchParams.append(paramName, startattach);
+        url.searchParams.set(paramName, paramValue);
         return url.toString();
     }
 


### PR DESCRIPTION
Right now, when Telegram URL (`tg:` or `t.me`) is used as universal link, the SDK would pass the connection request as a `startattach` parameter. However, this parameter is only used by the bots that integrate using the attachment menu (and this mode is not available for the majority of users).

This update allows to use the more widely available `startapp` parameter that is used with Telegram Mini Apps. The developer just need to add an empty `startapp` parameter to their universal URL to indicate that they want to opt-in for it, e.g.: `https://t.me/{botName}/{miniAppName}?startapp`.

This update is backward-compatible and doesn't break anything.