### PR TITLE
Fix Cannot define multiple custom elements with the same tag

### DIFF
--- a/packages/ui/src/app/utils/web-api.ts
+++ b/packages/ui/src/app/utils/web-api.ts
@@ -84,7 +84,10 @@ export function fixMobileSafariActiveTransition(): void {
 }
 
 export function defineStylesRoot(): void {
-    customElements.define(globalStylesTag, class TcRootElement extends HTMLElement {});
+    if(!customElements.get(globalStylesTag)) {
+        // A custom element with the same name can be only defined once,
+        customElements.define(globalStylesTag, class TcRootElement extends HTMLElement {});
+    } 
 }
 
 /**


### PR DESCRIPTION
- Currently TonConnect UI always initialises its custom web component "global styles" when `new TonconnectUI()` is called
- Currently `defineStylesRoot` calls `customElements.define(globalStylesTag)` 
- `customElements.define()` can be called only once 
-> Trying to initialise TonConnectUI in the same app twice crashes with
-> This prevents building an app that has TonConnectUI loaded twice or used twice

```
Cannot define multiple custom elements with the same tag
```

(Telegram Desktop Webkit / Safari error. The actual error message may vary)

As a workaround, this patch only calls `customElements.define` if we do not have our custom styles element defined yet by checking the registry.