### PR TITLE
Allow tonconnect/ui to be created twice

### DIFF
--- a/packages/ui/src/app/utils/web-api.ts
+++ b/packages/ui/src/app/utils/web-api.ts
@@ -84,7 +84,9 @@ export function fixMobileSafariActiveTransition(): void {
 }
 
 export function defineStylesRoot(): void {
-    customElements.define(globalStylesTag, class TcRootElement extends HTMLElement {});
+    if (!customElements.get(globalStylesTag)) {
+        customElements.define(globalStylesTag, class TcRootElement extends HTMLElement {});
+    }
 }
 
 /**


### PR DESCRIPTION
Currently every time `TonConnectUI` initialized it tries to add to `customElements` and when application changes pages and initialized second time it throws an error 
```
Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': this name has already been used with this registry
```

I added condition to check if `customElements` exists.

Not sure, but probably should fix #171
Tested in Solidjs app.