### PR TITLE
pass more ui options to TonConnect

### DIFF
--- a/packages/ui/src/models/ton-connect-ui-options.ts
+++ b/packages/ui/src/models/ton-connect-ui-options.ts
@@ -27,6 +27,16 @@ export interface TonConnectUiOptions {
     walletsListConfiguration?: WalletsListConfiguration;
 
     /**
+     * Url to the wallets list JSON file.
+     */
+    walletsListSource?: string;
+
+    /**
+     * Wallets list cache time to live.
+     */
+    walletsListCacheTTLMs?: number;
+
+    /**
      * Configuration for action-period (e.g. sendTransaction) UI elements: modals and notifications and wallet behaviour (return strategy).
      */
     actionsConfiguration?: ActionConfiguration;

--- a/packages/ui/src/ton-connect-ui.ts
+++ b/packages/ui/src/ton-connect-ui.ts
@@ -195,7 +195,11 @@ export class TonConnectUI {
         } else if (options && 'manifestUrl' in options && options.manifestUrl) {
             this.connector = new TonConnect({
                 manifestUrl: options.manifestUrl,
-                eventDispatcher: options?.eventDispatcher
+                eventDispatcher: options?.eventDispatcher,
+                ...(options.walletsListSource &&
+                    { walletsListSource: options.walletsListSource }),
+                ...(options.walletsListCacheTTLMs && options.walletsListCacheTTLMs > 0 &&
+                    {walletsListCacheTTLMs: options.walletsListCacheTTLMs}),
             });
         } else {
             throw new TonConnectUIError(


### PR DESCRIPTION
Currently the `walletsListSource` and `walletsListCacheTTLMs` options are not used, this commit pass them to `TonConnect`