### PR TITLE
fix the `tryGetWindowKeys` method to get the currently injected wallet

### DIFF
--- a/packages/sdk/src/utils/web-api.ts
+++ b/packages/sdk/src/utils/web-api.ts
@@ -10,17 +10,17 @@ export function getWindow(): Window | undefined {
 }
 
 /**
- * The function try to get window keys, if it is not available it returns empty array.
+ * The function try to get window entries, if it is not available it returns empty array.
  * As an example, for Safari's private mode it returns empty array, because the browser does not allow to get window keys.
  */
-export function tryGetWindowKeys(): string[] {
+export function tryGetWindowKeys(): [string, any][] {
     const window = getWindow();
     if (!window) {
         return [];
     }
 
     try {
-        return Object.keys(window);
+        return Object.entries(window);
     } catch {
         return [];
     }


### PR DESCRIPTION
fix method
```js
export function tryGetWindowKeys(): string[] {
    const window = getWindow();
    if (!window) {
        return [];
    }

    try {
        return Object.keys(window);
    } catch {
        return [];
    }
}
```
to
```js
export function tryGetWindowKeys(): [string, any][] {
    const window = getWindow();
    if (!window) {
        return [];
    }

    try {
        return Object.entries(window);
    } catch {
        return [];
    }
}
```

in `injected-provider.ts` file
`windowKeys` is to get the keys and entries of the window. 
```js
export class InjectedProvider<T extends string = string> implements InternalProvider {

    ...

    public static getCurrentlyInjectedWallets(): WalletInfoCurrentlyInjected[] {
        if (!this.window) {
            return [];
        }

        const windowKeys = tryGetWindowKeys();
        const wallets = windowKeys.filter(([_, value]) =>
            isJSBridgeWithMetadata(value)
        ) as unknown as [string, { tonconnect: InjectedWalletApi }][];

    ...

}
```

