### PR TITLE
build: externalize react/jsx-runtime and react-dom/client 

### DIFF
--- a/packages/ui-react/vite.config.ts
+++ b/packages/ui-react/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
       }
     },
     rollupOptions: {
-      external: ['react', 'react-dom', '@tonconnect/ui'],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client', '@tonconnect/ui'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
Optimizes bundeling sizes, because at the moment react/jsx-runtime is being bundled unnecessary leading to a overhead in production, by externalizing react/jsx-runtime and also for the future react-dom/client

Would be awesome for having a quick merge, because no breaking change, no problem, just removes overhead, reduce bundle size, and also provides a fix.

Also Fixes #216 