### PR TITLE
feat(ui): primary wallet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
                             },
                             {
                                 "sourceTag": "scope:ui",
-                                "onlyDependOnLibsWithTags": ["scope:core"]
+                                "onlyDependOnLibsWithTags": ["scope:sdk"]
+                            },
+                            {
+                                "sourceTag": "scope:ui-react",
+                                "onlyDependOnLibsWithTags": ["scope:ui"]
                             }
                         ]
                     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 .idea
+.vscode
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -7531,8 +7531,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -18102,7 +18101,7 @@
     },
     "packages/sdk": {
       "name": "@tonconnect/sdk",
-      "version": "3.0.3-beta.0",
+      "version": "3.0.6-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tonconnect/isomorphic-eventsource": "^0.0.2",
@@ -18606,11 +18605,12 @@
     },
     "packages/ui": {
       "name": "@tonconnect/ui",
-      "version": "2.0.3-beta.2",
+      "version": "2.0.10-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tonconnect/sdk": "3.0.3-beta.0",
+        "@tonconnect/sdk": "3.0.6-beta.0",
         "classnames": "^2.3.2",
+        "csstype": "^3.1.1",
         "deepmerge": "^4.2.2",
         "ua-parser-js": "^1.0.35"
       },
@@ -18620,7 +18620,6 @@
         "@solid-primitives/i18n": "^1.1.2",
         "@types/node": "^18.11.17",
         "@types/ua-parser-js": "^0.7.36",
-        "csstype": "^3.1.1",
         "eslint-plugin-solid": "^0.7.3",
         "is-plain-object": "^5.0.0",
         "qrcode-generator": "^1.4.4",
@@ -18638,10 +18637,10 @@
     },
     "packages/ui-react": {
       "name": "@tonconnect/ui-react",
-      "version": "2.0.3-beta.2",
+      "version": "2.0.10-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tonconnect/ui": "2.0.3-beta.2"
+        "@tonconnect/ui": "2.0.10-beta.3"
       },
       "devDependencies": {
         "@types/react": "^18.0.26",
@@ -23171,7 +23170,7 @@
         "@floating-ui/dom": "^1.0.12",
         "@rollup/plugin-replace": "5.0.5",
         "@solid-primitives/i18n": "^1.1.2",
-        "@tonconnect/sdk": "3.0.3-beta.0",
+        "@tonconnect/sdk": "3.0.6-beta.0",
         "@types/node": "^18.11.17",
         "@types/ua-parser-js": "^0.7.36",
         "classnames": "^2.3.2",
@@ -23342,7 +23341,7 @@
     "@tonconnect/ui-react": {
       "version": "file:packages/ui-react",
       "requires": {
-        "@tonconnect/ui": "2.0.3-beta.2",
+        "@tonconnect/ui": "2.0.10-beta.3",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.0.0",
@@ -25520,8 +25519,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "dargs": {
       "version": "7.0.0",

--- a/packages/sdk/.eslintrc.js
+++ b/packages/sdk/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: ["../../.eslintrc.js"],
+    extends: ['../../.eslintrc.js'],
     overrides: [
         {
             files: './vite.config.ts',
@@ -9,6 +9,12 @@ module.exports = {
                 tsconfigRootDir: __dirname,
                 createDefaultProgram: true
             },
+            '@nx/enforce-module-boundaries': [
+                'error',
+                {
+                    allow: ['scope:protocol']
+                }
+            ]
         }
     ]
 };

--- a/packages/ui-react/src/components/TonConnectUIProvider.tsx
+++ b/packages/ui-react/src/components/TonConnectUIProvider.tsx
@@ -61,6 +61,11 @@ export interface TonConnectUIProviderPropsBase {
     walletsListConfiguration?: WalletsListConfiguration;
 
     /**
+     * App name of the wallet to display prominently in the wallets list.
+     */
+    primaryWalletAppName?: string;
+
+    /**
      * Configuration for action-period (e.g. sendTransaction) UI elements: modals and notifications and wallet behaviour (return strategy).
      */
     actionsConfiguration?: ActionConfiguration;

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -43,7 +43,7 @@ You can find `TonConnectUI` in global variable `TON_CONNECT_UI`, e.g.
 
 ## Create TonConnectUI instance
 ```ts
-import TonConnectUI from '@tonconnect/ui'
+import { TonConnectUI } from '@tonconnect/ui'
 
 const tonConnectUI = new TonConnectUI({
     manifestUrl: 'https://<YOUR_APP_URL>/tonconnect-manifest.json',

--- a/packages/ui/src/app/assets/i18n/en.json
+++ b/packages/ui/src/app/assets/i18n/en.json
@@ -40,20 +40,23 @@
     "popular": "Popular"
   },
   "walletModal": {
-    "loading": "Loading wallets",
+    "loading": "Loading Wallets",
     "wallets": "Wallets",
     "mobileUniversalModal": {
       "connectYourWallet": "Connect your TON wallet",
+      "openPrimaryWalletOrSelect": "Open {{ name }} or select your wallet to connect",
       "openWalletOnTelegramOrSelect": "Use Wallet in Telegram or choose other application",
       "openWalletOnTelegram": "Connect Wallet in Telegram",
+      "openWallet": "Open {{ name }}",
       "chooseOtherApplication": "Choose other application",
+      "chooseOtherWallet": "Choose other Wallet",
       "openLink": "Open Link",
       "scan": "Scan with your mobile wallet"
     },
     "desktopUniversalModal": {
       "connectYourWallet": "Connect your TON wallet",
       "scan": "Scan with your mobile wallet",
-      "availableWallets": "Available wallets"
+      "availableWallets": "Available Wallets"
     },
     "mobileConnectionModal": {
       "showQR": "Show QR Code",
@@ -62,6 +65,7 @@
       "connectionDeclined": "Connection declined"
     },
     "desktopConnectionModal": {
+      "chooseOtherWallet": "Choose other Wallet",
       "scanQR": "Scan the QR code below with your phone’s or {{ name }}’s camera",
       "continueInExtension": "Continue in {{ name }} browser extension…",
       "dontHaveExtension": "Seems you don't have installed {{ name }} browser extension",

--- a/packages/ui/src/app/assets/i18n/ru.json
+++ b/packages/ui/src/app/assets/i18n/ru.json
@@ -44,16 +44,19 @@
     "wallets": "Кошельки",
     "mobileUniversalModal": {
       "connectYourWallet": "Подключите TON кошелёк",
+      "openPrimaryWalletOrSelect": "Открыть {{ name }} или выберете ваш кошелек для соединения",
       "openWalletOnTelegramOrSelect": "Подключите Wallet в Telegram или выберете другое приложение",
       "openWalletOnTelegram": "Открыть Wallet в Telegram",
+      "openWallet": "Открыть {{ name }}",
       "chooseOtherApplication": "Выберите другое приложение",
+      "chooseOtherWallet": "Выбрать другой Кошелёк",
       "openLink": "Открыть",
       "scan": "Отсканируйте камерой вашего телефона"
     },
     "desktopUniversalModal": {
       "connectYourWallet": "Подключите TON кошелёк",
       "scan": "Отсканируйте QR-код камерой вашего телефона",
-      "availableWallets": "Доступные кошельки"
+      "availableWallets": "Доступные Кошельки"
     },
     "mobileConnectionModal": {
       "showQR": "Показать QR-код",
@@ -62,6 +65,7 @@
       "connectionDeclined": "Подключение отклонено"
     },
     "desktopConnectionModal": {
+      "chooseOtherWallet": "Выбрать другой Кошелёк",
       "scanQR": "Отсканируйте QR-код ниже камерой в приложении {{ name }}, или камерой телефона",
       "continueInExtension": "Откройте браузерное расширение {{ name }}",
       "dontHaveExtension": "Похоже, у вас не установлено браузерное расширение {{ name }}",

--- a/packages/ui/src/app/state/app.state.ts
+++ b/packages/ui/src/app/state/app.state.ts
@@ -15,6 +15,7 @@ export type AppState = {
     twaReturnUrl: `${string}://${string}` | undefined;
     preferredWalletAppName: string | undefined;
     enableAndroidBackHandler: boolean;
+    primaryWalletAppName: string | undefined;
 };
 
 export const [appState, setAppState] = createStore<AppState>({

--- a/packages/ui/src/app/views/modals/wallets-modal/desktop-connection-modal/index.tsx
+++ b/packages/ui/src/app/views/modals/wallets-modal/desktop-connection-modal/index.tsx
@@ -17,6 +17,7 @@ import {
     useContext
 } from 'solid-js';
 import {
+    AllWalletsButton,
     BodyStyled,
     BodyTextStyled,
     BottomButtonsContainerStyled,
@@ -34,6 +35,7 @@ import {
 } from './style';
 import { ConnectorContext } from 'src/app/state/connector.context';
 import {
+    ArrowIcon,
     BrowserIcon,
     Button,
     DesktopIcon,
@@ -59,6 +61,7 @@ export interface DesktopConnectionProps {
     additionalRequest?: ConnectAdditionalRequest;
     wallet: WalletInfoRemote | (WalletInfoRemote & WalletInfoInjectable);
     onBackClick: () => void;
+    onAllWalletsClick?: () => void;
     backDisabled?: boolean;
 }
 
@@ -328,6 +331,17 @@ export const DesktopConnectionModal: Component<DesktopConnectionProps> = props =
                         </FooterButton>
                     </Show>
                 </BottomButtonsContainerStyled>
+            </Show>
+            <Show when={props.onAllWalletsClick}>
+                <AllWalletsButton
+                    appearance="flat"
+                    onClick={() => props.onAllWalletsClick?.()}
+                    rightIcon={<ArrowIcon direction="right" />}
+                >
+                    <Translation translationKey="walletModal.desktopConnectionModal.chooseOtherWallet">
+                        Choose other Wallet
+                    </Translation>
+                </AllWalletsButton>
             </Show>
         </DesktopConnectionModalStyled>
     );

--- a/packages/ui/src/app/views/modals/wallets-modal/desktop-connection-modal/style.ts
+++ b/packages/ui/src/app/views/modals/wallets-modal/desktop-connection-modal/style.ts
@@ -1,5 +1,14 @@
 import { styled } from 'solid-styled-components';
-import {Button, ErrorIcon, H1, H2, IconButton, LoaderIcon, Image, QRCode} from 'src/app/components';
+import {
+    Button,
+    ErrorIcon,
+    H1,
+    H2,
+    IconButton,
+    LoaderIcon,
+    Image,
+    QRCode
+} from 'src/app/components';
 import { BorderRadiusConfig } from 'src/app/models/border-radius-config';
 
 const tgButtonBorders: BorderRadiusConfig = {
@@ -31,6 +40,16 @@ export const BodyStyled = styled.div<{ qr: boolean }>`
 
 export const QRCodeStyled = styled(QRCode)`
     margin-bottom: 24px;
+`;
+
+export const AllWalletsButton = styled(Button)`
+    padding-bottom: 24px;
+    display: flex;
+    justify-content: center;
+    font-weight: 400;
+    font-size: 16px;
+    margin: 0 auto;
+    color: ${props => props.theme!.colors.text.secondary};
 `;
 
 export const H1Styled = styled(H1)`

--- a/packages/ui/src/app/views/modals/wallets-modal/desktop-universal-modal/index.tsx
+++ b/packages/ui/src/app/views/modals/wallets-modal/desktop-universal-modal/index.tsx
@@ -6,7 +6,7 @@ import {
     QRCodeStyled,
     WalletsContainerStyled
 } from './style';
-import { ConnectAdditionalRequest, isWalletInfoRemote, WalletInfo } from '@tonconnect/sdk';
+import { ConnectAdditionalRequest, WalletInfo } from '@tonconnect/sdk';
 import { appState } from 'src/app/state/app.state';
 import { setLastSelectedWalletInfo } from 'src/app/state/modals-state';
 import { FourWalletsItem, H1, WalletLabeledItem } from 'src/app/components';
@@ -24,6 +24,8 @@ interface DesktopUniversalModalProps {
     onSelect: (walletInfo: WalletInfo) => void;
 
     onSelectAllWallets: () => void;
+
+    primaryWalletAppName?: string;
 }
 
 export const DesktopUniversalModal: Component<DesktopUniversalModalProps> = props => {
@@ -35,6 +37,7 @@ export const DesktopUniversalModal: Component<DesktopUniversalModalProps> = prop
     });
 
     setLastSelectedWalletInfo({ openMethod: 'qrcode' });
+
     const request = createMemo(() => connector.connect(walletsBridges(), props.additionalRequest));
 
     return (
@@ -54,7 +57,7 @@ export const DesktopUniversalModal: Component<DesktopUniversalModalProps> = prop
                 imageUrl={IMG.TON}
             />
             <H2AvailableWalletsStyled translationKey="walletModal.desktopUniversalModal.availableWallets">
-                Available wallets
+                Available Wallets
             </H2AvailableWalletsStyled>
             <WalletsContainerStyled>
                 <For each={props.walletsList.slice(0, 3)}>

--- a/packages/ui/src/app/views/modals/wallets-modal/mobile-universal-modal/mobile-universal-qr/index.tsx
+++ b/packages/ui/src/app/views/modals/wallets-modal/mobile-universal-modal/mobile-universal-qr/index.tsx
@@ -1,13 +1,13 @@
 import { Component } from 'solid-js';
 import { H1Styled, H2Styled, QrCodeWrapper, ButtonsWrapper, ActionButton } from './style';
 import { QRCode } from 'src/app/components';
-import { IMG } from 'src/app/env/IMG';
 
 import { addReturnStrategy } from 'src/app/utils/url-strategy-helpers';
 import { Translation } from 'src/app/components/typography/Translation';
 
 interface MobileUniversalQRProps {
     universalLink: string;
+    imageUrl: string;
     onOpenLink: () => void;
     onCopy: () => void;
     isCopiedShown: ReturnType<typeof setTimeout> | void;
@@ -24,7 +24,7 @@ export const MobileUniversalQR: Component<MobileUniversalQRProps> = props => {
             </H2Styled>
             <QrCodeWrapper>
                 <QRCode
-                    imageUrl={IMG.TON}
+                    imageUrl={props.imageUrl}
                     sourceUrl={addReturnStrategy(props.universalLink, 'none')}
                     disableCopy
                 />

--- a/packages/ui/src/app/views/modals/wallets-modal/mobile-universal-modal/style.ts
+++ b/packages/ui/src/app/views/modals/wallets-modal/mobile-universal-modal/style.ts
@@ -46,6 +46,16 @@ export const OtherOptionButton = styled.li`
     }
 `;
 
+export const AllWalletsButton = styled(Button)`
+    padding-bottom: 24px;
+    display: flex;
+    justify-content: center;
+    font-weight: 400;
+    font-size: 16px;
+    margin: 0 auto;
+    color: ${props => props.theme!.colors.text.secondary};
+`;
+
 export const H1Styled = styled(H1)`
     margin-top: 38px;
     margin-bottom: 4px;
@@ -71,7 +81,7 @@ export const ButtonStyled = styled(Button)`
     margin: 0 auto;
 `;
 
-export const TelegramButtonStyled = styled(Button)`
+export const PrimaryButtonStyled = styled(Button)`
     margin: 0 28px 24px;
     width: calc(100% - 56px);
     border-radius: ${props => borders[props.theme!.borderRadius]};
@@ -100,4 +110,9 @@ export const StyledLeftActionButton = styled(IconButton)`
     position: absolute;
     top: 16px;
     left: 16px;
+`;
+
+export const PrimaryButtonIconPlaceholder = styled.div`
+    width: 28px;
+    height: 28px;
 `;

--- a/packages/ui/src/app/views/modals/wallets-modal/single-wallet-modal.tsx
+++ b/packages/ui/src/app/views/modals/wallets-modal/single-wallet-modal.tsx
@@ -11,8 +11,7 @@ import {
 import { ConnectorContext } from 'src/app/state/connector.context';
 import {
     getSingleWalletModalIsOpened,
-    getSingleWalletModalWalletInfo,
-    setSingleWalletModalState
+    getSingleWalletModalWalletInfo
 } from 'src/app/state/modals-state';
 import { H1Styled, LoaderContainerStyled, StyledModal } from './style';
 import { useI18n } from '@solid-primitives/i18n';

--- a/packages/ui/src/app/views/modals/wallets-modal/style.ts
+++ b/packages/ui/src/app/views/modals/wallets-modal/style.ts
@@ -11,8 +11,6 @@ export const StyledModal = styled(Modal)`
     ${media('mobile')} {
         padding-left: 0;
         padding-right: 0;
-
-        min-height: 364px;
     }
 `;
 

--- a/packages/ui/src/models/colors-set.ts
+++ b/packages/ui/src/models/colors-set.ts
@@ -1,6 +1,10 @@
 import type { Property } from 'csstype';
 type Color = Property.Color;
 
+type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
 export type ColorsSet = {
     constant: {
         black: Color;
@@ -32,33 +36,4 @@ export type ColorsSet = {
     };
 };
 
-export type PartialColorsSet = {
-    constant?: {
-        black?: Color;
-        white?: Color;
-    };
-    connectButton?: {
-        background?: Color;
-        foreground?: Color;
-    };
-    accent?: Color;
-    telegramButton?: Color;
-    icon?: {
-        primary?: Color;
-        secondary?: Color;
-        tertiary?: Color;
-        success?: Color;
-        error?: Color;
-    };
-    background?: {
-        primary?: Color;
-        secondary?: Color;
-        segment?: Color;
-        tint?: Color;
-        qr?: Color;
-    };
-    text?: {
-        primary?: Color;
-        secondary?: Color;
-    };
-};
+export type PartialColorsSet = DeepPartial<ColorsSet>;

--- a/packages/ui/src/models/ton-connect-ui-options.ts
+++ b/packages/ui/src/models/ton-connect-ui-options.ts
@@ -27,6 +27,11 @@ export interface TonConnectUiOptions {
     walletsListConfiguration?: WalletsListConfiguration;
 
     /**
+     * App name of the wallet to display prominently in the wallets list.
+     */
+    primaryWalletAppName?: string;
+
+    /**
      * Configuration for action-period (e.g. sendTransaction) UI elements: modals and notifications and wallet behaviour (return strategy).
      */
     actionsConfiguration?: ActionConfiguration;

--- a/packages/ui/src/ton-connect-ui.ts
+++ b/packages/ui/src/ton-connect-ui.ts
@@ -19,7 +19,7 @@ import { TonConnectUIError } from 'src/errors/ton-connect-ui.error';
 import { TonConnectUiCreateOptions } from 'src/models/ton-connect-ui-create-options';
 import { PreferredWalletStorage, WalletInfoStorage } from 'src/storage';
 import {
-    createMacrotask, createMacrotaskAsync,
+    createMacrotaskAsync,
     getSystemTheme,
     preloadImages,
     subscribeToThemeChange
@@ -67,6 +67,8 @@ export class TonConnectUI {
     private actionsConfiguration?: ActionConfiguration;
 
     private readonly walletsList: Promise<WalletInfo[]>;
+
+    public readonly primaryWalletAppName?: string;
 
     private connectRequestParametersCallback?: (
         parameters: ConnectAdditionalRequest | undefined
@@ -162,6 +164,12 @@ export class TonConnectUI {
         setAppState(state => {
             const merged = mergeOptions(
                 {
+                    ...(options.hasOwnProperty('primaryWalletAppName') && {
+                        primaryWalletAppName:
+                            options.primaryWalletAppName === null
+                                ? undefined
+                                : options.primaryWalletAppName
+                    }),
                     ...(options.language && { language: options.language }),
                     ...(!!options.actionsConfiguration?.returnStrategy && {
                         returnStrategy: options.actionsConfiguration.returnStrategy
@@ -234,6 +242,8 @@ export class TonConnectUI {
 
         this.walletsList = this.getWallets();
 
+        this.primaryWalletAppName = options.primaryWalletAppName;
+
         this.walletsList.then(list => preloadImages(uniq(list.map(item => item.imageUrl))));
 
         const rootId = this.normalizeWidgetRoot(options?.widgetRootId);
@@ -260,7 +270,8 @@ export class TonConnectUI {
         const preferredWalletName = this.preferredWalletStorage.getPreferredWalletAppName();
         setAppState({
             connector: this.connector,
-            preferredWalletAppName: preferredWalletName
+            preferredWalletAppName: preferredWalletName,
+            primaryWalletAppName: this.primaryWalletAppName
         });
 
         widgetController.renderApp(rootId, this);


### PR DESCRIPTION
This PR introduces the feature to select a primary wallet in ton-connect. As a follow-up, we should extend `WalletInfoDTO` to include an optional field for styling parameters, supporting both dark and light themes, to ensure full theme customization