### PR TITLE
docs: Include telegram-web-app.js

### DIFF
--- a/docs/modules/_tonconnect_ui.html
+++ b/docs/modules/_tonconnect_ui.html
@@ -230,7 +230,7 @@ a URL: wallet will open this URL after completing the user&#39;s action. Note, t
   <h2>Use inside TMA (Telegram Mini Apps)</h2>
 </a>
 <p>TonConnect UI will work in TMA in the same way as in a regular website!
-Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script inside the `header` block of your HTML:</p>
+Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script inside the header block of your HTML:</p>
 <pre><code class="language-html">&lt;header&gt;
   &lt;script src="https://telegram.org/js/telegram-web-app.js"&gt;&lt;/script&gt;
 &lt;/header&gt;</code></pre>

--- a/docs/modules/_tonconnect_ui.html
+++ b/docs/modules/_tonconnect_ui.html
@@ -230,6 +230,8 @@ a URL: wallet will open this URL after completing the user&#39;s action. Note, t
   <h2>Use inside TMA (Telegram Mini Apps)</h2>
 </a>
 <p>TonConnect UI will work in TMA in the same way as in a regular website!
+Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script in the HTML header:</p>
+<pre><code class="language-html"><script src="https://telegram.org/js/telegram-web-app.js"></script></code></pre>
 Basically, no changes are required from the dApp&#39;s developers. The only thing you have to set is a dynamic return strategy.</p>
 <p>Currently, it is impossible for TMA-wallets to redirect back to previous opened TMA-dApp like native wallet-apps do.
 It means, that you need to specify the return strategy as a link to your TMA that will be only applied if the dApp is opened in TMA mode.</p>

--- a/docs/modules/_tonconnect_ui.html
+++ b/docs/modules/_tonconnect_ui.html
@@ -230,9 +230,11 @@ a URL: wallet will open this URL after completing the user&#39;s action. Note, t
   <h2>Use inside TMA (Telegram Mini Apps)</h2>
 </a>
 <p>TonConnect UI will work in TMA in the same way as in a regular website!
-Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script in the HTML header:</p>
-<pre><code class="language-html"><script src="https://telegram.org/js/telegram-web-app.js"></script></code></pre>
-Basically, no changes are required from the dApp&#39;s developers. The only thing you have to set is a dynamic return strategy.</p>
+Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script inside the `<header>` block of your HTML:</p>
+<pre><code class="language-html">&lt;header&gt;
+  &lt;script src="https://telegram.org/js/telegram-web-app.js"&gt;&lt;/script&gt;
+&lt;/header&gt;</code></pre>
+Basically, no additional changes are required from the dApp&#39;s developers. The only thing you have to set is a dynamic return strategy.</p>
 <p>Currently, it is impossible for TMA-wallets to redirect back to previous opened TMA-dApp like native wallet-apps do.
 It means, that you need to specify the return strategy as a link to your TMA that will be only applied if the dApp is opened in TMA mode.</p>
 <pre><code class="language-ts"><span class="hl-2">tonConnectUI</span><span class="hl-1">.</span><span class="hl-2">uiOptions</span><span class="hl-1"> = {</span><br/><span class="hl-1">    </span><span class="hl-2">twaReturnUrl:</span><span class="hl-1"> </span><span class="hl-3">&#39;https://t.me/durov&#39;</span><br/><span class="hl-1">};</span>

--- a/docs/modules/_tonconnect_ui.html
+++ b/docs/modules/_tonconnect_ui.html
@@ -230,7 +230,7 @@ a URL: wallet will open this URL after completing the user&#39;s action. Note, t
   <h2>Use inside TMA (Telegram Mini Apps)</h2>
 </a>
 <p>TonConnect UI will work in TMA in the same way as in a regular website!
-Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script inside the `<header>` block of your HTML:</p>
+Developers need to ensure that the Telegram Mini Apps environment is detected correctly by including the following script inside the `header` block of your HTML:</p>
 <pre><code class="language-html">&lt;header&gt;
   &lt;script src="https://telegram.org/js/telegram-web-app.js"&gt;&lt;/script&gt;
 &lt;/header&gt;</code></pre>


### PR DESCRIPTION
Added a mention of the importance of including` telegram-web-app.js` in the <head></head> section of HTML to ensure proper platform detection via `window.Telegram.WebApp.platform`.

This is crucial to avoid the **ERR_UNKNOWN_URL_SCHEME** error within the mini app when attempting to call external URL handlers such as `tonkeeper://`.