### PR TITLE
feat(ui): add excludeWallets to walletsListConfiguration

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -686,6 +686,18 @@ tonConnectUI.uiOptions = {
 }
 ```
 
+### Exclude wallets
+Pass wallet names to be excluded from the wallets list. Passed names will be used to filter out any wallet to be hidden.  
+
+Since the filtering with `excludeWallets` is processed last when applying wallet configuration, it should take precedence over `includeWallets`.  
+```ts
+tonConnectUI.uiOptions = {
+    walletsListConfiguration: {
+        excludeWallets: ['xtonwallet']
+    }
+}
+```
+
 ## Add connect request parameters (ton_proof)
 Use `tonConnectUI.setConnectRequestParameters` function to pass your connect request parameters.
 

--- a/packages/ui/src/app/utils/wallets.ts
+++ b/packages/ui/src/app/utils/wallets.ts
@@ -31,6 +31,12 @@ export function applyWalletsListConfiguration(
         );
     }
 
+    if (configuration.excludeWallets?.length) {
+        walletsList = walletsList.filter(v => {
+            return !configuration.excludeWallets?.find(w => eqWalletName(v, w));
+        });
+    }
+
     return walletsList;
 }
 

--- a/packages/ui/src/dev.ts
+++ b/packages/ui/src/dev.ts
@@ -31,7 +31,8 @@ async function dev(): Promise<void> {
                     imageUrl: 'https://tonkeeper.com/assets/tonconnect-icon.png',
                     platforms: ['ios']
                 }
-            ]
+            ],
+            excludeWallets: ['xtonwallet']
         }*/
     });
 

--- a/packages/ui/src/models/wallets-list-configuration.ts
+++ b/packages/ui/src/models/wallets-list-configuration.ts
@@ -1,11 +1,12 @@
 import { UIWallet } from './ui-wallet';
 
 /**
- * Add corrections to the default wallets list in the modal: add custom wallets and change wallets order.
+ * Add corrections to the default wallets list in the modal: add custom wallets, exclude wallets and change wallets order.
  */
 export type WalletsListConfiguration = {
     /**
      * Allows to include extra wallets to the wallets list in the modal.
      */
     includeWallets?: UIWallet[];
+    excludeWallets?: UIWallet['name'][];
 };


### PR DESCRIPTION
This PR allows `walletsListConfiguration` to be customized with `excludeWallets`. It mainly serves the purpose of hiding unsupported or unwanted wallets when connecting. 

### Exclude wallets
Pass wallet names to be excluded from the wallets list. Passed names will be used to filter out any wallet to be hidden.  

Since the filtering with `excludeWallets` is processed last when applying wallet configuration, it should take precedence over `includeWallets`.  
```ts
tonConnectUI.uiOptions = {
    walletsListConfiguration: {
        excludeWallets: ['xtonwallet']
    }
}
```