### PR TITLE
Support react@19 in @tonconnect/ui-react

### DIFF
--- a/packages/ui-react/vite.config.ts
+++ b/packages/ui-react/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
       }
     },
     rollupOptions: {
-      external: ['react', 'react-dom', '@tonconnect/ui'],
+      external: ['react', 'react-dom', '@tonconnect/ui', 'react/jsx-runtime'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
Currently 'react/jsx-runtime' is not marked as external. Thats why is fails to work with react 19
fixes #216 #290 #323
