### PR TITLE
Prevent leaking dApp locator

### DIFF
--- a/packages/sdk/src/wallets-list-manager.ts
+++ b/packages/sdk/src/wallets-list-manager.ts
@@ -81,7 +81,9 @@ export class WalletsListManager {
         let walletsList: WalletInfoDTO[] = [];
 
         try {
-            const walletsResponse = await fetch(this.walletsListSource);
+            const walletsResponse = await fetch(this.walletsListSource, {
+                referrer: ''
+            });
             walletsList = await walletsResponse.json();
 
             if (!Array.isArray(walletsList)) {


### PR DESCRIPTION
The previous implementation allowed to correlate users with dApps, and revealed addresses of dApps, on side of wallet list hoster.