### PR TITLE
fix(ui): don't preload 30+ pictures of wallets

### DIFF
--- a/packages/ui/src/ton-connect-ui.ts
+++ b/packages/ui/src/ton-connect-ui.ts
@@ -31,7 +31,6 @@ import { PreferredWalletStorage, WalletInfoStorage } from 'src/storage';
 import {
     createMacrotaskAsync,
     getSystemTheme,
-    preloadImages,
     subscribeToThemeChange
 } from 'src/app/utils/web-api';
 import { TonConnectUiOptions } from 'src/models/ton-connect-ui-options';
@@ -283,8 +282,6 @@ export class TonConnectUI {
         this._walletsPreferredFeatures = options.walletsPreferredFeatures;
 
         this.walletsList = this.getWallets();
-
-        this.walletsList.then(list => preloadImages(uniq(list.map(item => item.imageUrl))));
 
         const rootId = this.normalizeWidgetRoot(options?.widgetRootId);
 


### PR DESCRIPTION
This preload functionality generates a huge load on the CDN serving pictures.
The preload is unnecessary because the "Connect" button is not called all the time, and when it is called, only a few icons are shown.

Here is the Network tab where we can see all these pictures being loaded:
<img width="1512" height="904" alt="Screenshot 2025-11-27 at 19 34 50" src="https://github.com/user-attachments/assets/dd223c18-9a5b-4232-be20-97b21b8ab66b" />
<img width="1512" height="909" alt="Screenshot 2025-11-27 at 19 34 56" src="https://github.com/user-attachments/assets/9994a92f-10df-44af-a68c-b84f7d21e649" />

After this change, we can see that this is no longer the case:
<img width="1512" height="859" alt="Screenshot 2025-11-27 at 19 35 49" src="https://github.com/user-attachments/assets/d156ec17-739c-441a-a15d-6118583d0eb4" />

The FCP might have actually improved, but it's not certain:
<img width="1512" height="905" alt="Screenshot 2025-11-27 at 19 35 58" src="https://github.com/user-attachments/assets/bc5dbba8-0f36-4176-a7a5-384da9cef237" />

We can now see that when the Dialog is opened, pictures are loaded on-demand and displayed correctly:
<img width="1510" height="789" alt="Screenshot 2025-11-27 at 19 45 59" src="https://github.com/user-attachments/assets/1887eeda-4b2a-4923-bd26-1391a5cb8bc8" />
