### PR TITLE
refactor(ui): update Theme type to use template literal type

### DIFF
--- a/packages/ui/src/models/THEME.ts
+++ b/packages/ui/src/models/THEME.ts
@@ -3,4 +3,4 @@ export enum THEME {
     LIGHT = 'LIGHT'
 }
 
-export type Theme = THEME | 'SYSTEM';
+export type Theme = `${THEME}` | 'SYSTEM';


### PR DESCRIPTION
Without this change, the following code, despite being fully valid, will not pass TypeScript validation:

```ts
new TonConnectUI({
  uiPreferences: {
    theme: "DARK"
    // ^ Type '"DARK"' is not assignable to type 'Theme | undefined'.
  }
})
```

By declaring the `Theme` type via a string literal derived from the `THEME` enum values, the code above will pass TypeScript checks. 

This change will still allow the use of the values of the `THEME` enum without causing any regression. 

This change will allow us to configure the ton connect UI theme with a value from the app theme, matching the value that ton connect uses, without mapping the app value to the ton connect `THEME` enum. Also, it will allow to just use strings (with IDE auto completion and TS checks) without the need to import `THEME` enum