### PR TITLE
fix: handle missing injected device info

### DIFF
--- a/packages/sdk/src/provider/injected/injected-provider.ts
+++ b/packages/sdk/src/provider/injected/injected-provider.ts
@@ -118,8 +118,8 @@ export class InjectedProvider<T extends string = string> implements InternalProv
         if (analyticsManager) {
             this.analytics = analyticsManager.scoped({
                 bridge_key: injectedWalletKey,
-                wallet_app_name: this.injectedWallet.deviceInfo.appName,
-                wallet_app_version: this.injectedWallet.deviceInfo.appVersion
+                wallet_app_name: this.injectedWallet.deviceInfo?.appName ?? '',
+                wallet_app_version: this.injectedWallet.deviceInfo?.appVersion ?? ''
             });
         }
     }

--- a/packages/sdk/tests/provider/injected/injected-provider.test.ts
+++ b/packages/sdk/tests/provider/injected/injected-provider.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, vi } from 'vitest';
+import { AnalyticsManager } from 'src/analytics/analytics-manager';
+import { InjectedProvider } from 'src/provider/injected/injected-provider';
+import { InjectedWalletApi } from 'src/provider/injected/models/injected-wallet-api';
+import { BridgeConnectionStorage } from 'src/storage/bridge-connection-storage';
+
+describe('Injected provider', () => {
+    const originalWindow = (
+        InjectedProvider as unknown as {
+            window: Window | undefined;
+        }
+    ).window;
+
+    afterEach(() => {
+        (
+            InjectedProvider as unknown as {
+                window: Window | undefined;
+            }
+        ).window = originalWindow;
+    });
+
+    it('should initialize analytics if injected wallet does not provide deviceInfo', () => {
+        const injectedWalletKey = 'legacyTonWallet';
+        const injectedWallet = {
+            walletInfo: {
+                name: 'Legacy TON Wallet',
+                app_name: 'legacy-ton-wallet',
+                image: 'https://example.com/wallet.png',
+                about_url: 'https://example.com',
+                platforms: ['chrome'],
+                features: []
+            },
+            protocolVersion: 2,
+            isWalletBrowser: false,
+            connect: vi.fn(),
+            restoreConnection: vi.fn(),
+            send: vi.fn(),
+            listen: vi.fn(),
+            disconnect: vi.fn()
+        } as unknown as InjectedWalletApi;
+        const injectedWindow = {
+            [injectedWalletKey]: {
+                tonconnect: injectedWallet
+            }
+        } as unknown as Window;
+        const analyticsManager = {
+            scoped: vi.fn()
+        } as unknown as AnalyticsManager;
+
+        (
+            InjectedProvider as unknown as {
+                window: Window | undefined;
+            }
+        ).window = injectedWindow;
+
+        expect(
+            () =>
+                new InjectedProvider(
+                    {} as BridgeConnectionStorage,
+                    injectedWalletKey,
+                    analyticsManager
+                )
+        ).not.toThrow();
+        expect(analyticsManager.scoped).toHaveBeenCalledWith({
+            bridge_key: injectedWalletKey,
+            wallet_app_name: '',
+            wallet_app_version: ''
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fix injected wallet connection failure when a wallet provider does not expose `deviceInfo`.

## Motivation

After analytics was added to the SDK, `InjectedProvider` started reading:

```ts
this.injectedWallet.deviceInfo.appName
this.injectedWallet.deviceInfo.appVersion
```

during initialization.
This makes analytics metadata mandatory at runtime. However, some already released wallet apps expose a valid injected TON Connect provider without deviceInfo. These wallets can still support the required connection methods, but the SDK throws before the connection flow can start:
TypeError: undefined is not an object (evaluating 'this.injectedWallet.deviceInfo.appName')
Wallet apps can add deviceInfo in future releases, but already released versions cannot be fixed retroactively. Since analytics should not block the core connection flow, the SDK should handle missing analytics metadata gracefully.